### PR TITLE
Automate initialize reader SDK step

### DIFF
--- a/hooks/addSquareInit.js
+++ b/hooks/addSquareInit.js
@@ -1,0 +1,71 @@
+module.exports = function(ctx) {
+
+  var fs = ctx.requireCordovaModule('fs');
+  var path = ctx.requireCordovaModule('path');
+
+  // Read project config file and get the name of the project
+  var config_path = path.join(__dirname, '/../../../config.xml');
+
+  fs.readFile(config_path, 'utf8', function(err, data) {
+
+    if (!err && data) {
+
+      var name_start = data.indexOf('<name>');
+      var name_end = data.indexOf('</name>');
+
+      var project_name = data.substring(name_start, name_end);
+      project_name = project_name.replace('<name>', '').trim();
+
+      // next we need to read the file app delegate file
+      var app_delegate_path = path.join(__dirname,'/../../../platforms/ios/' + project_name + '/Classes/AppDelegate.m');
+
+      fs.readFile(app_delegate_path, 'utf8', function(err, data) {
+        if (!err && data) {
+
+          // Add the import for the square sdk header file
+          var square_import_search_string = '#import "MainViewController.h"';
+          var square_import_start = data.indexOf(square_import_search_string) + square_import_search_string.length;
+
+          var content_start = data.substring(0, square_import_start);
+          var content_end = data.substring(square_import_start);
+
+          var new_app_delegate_content = content_start;
+          new_app_delegate_content += '\n#import <SquareReaderSDK/SquareReaderSDK.h>';
+          new_app_delegate_content += content_end;
+
+          // Add the code to initialize the square reader sdk
+          var square_init_search_string = '{';
+          var square_init_start = new_app_delegate_content.indexOf(square_init_search_string) + square_init_search_string.length;
+
+          content_start = new_app_delegate_content.substring(0, square_init_start);
+          content_end = new_app_delegate_content.substring(square_init_start);
+
+          new_app_delegate_content = content_start;
+          new_app_delegate_content += '\n\t// Initialize Square Reader SDK\n\t[SQRDReaderSDK initializeWithApplicationLaunchOptions:launchOptions];';
+          new_app_delegate_content += content_end;
+
+          // Write to the file with the new updates
+          fs.writeFile(app_delegate_path, new_app_delegate_content, function(err) {
+            if (!err) {
+              console.log('\x1b[32m%s\x1b[0m', 'Success! The Square SDK initializer was added to the AppDelegate file');
+            } else {
+              console.log('\x1b[31m%s\x1b[0m', 'Error: Could not update app delegate file');
+            }
+          });
+
+        } else {
+
+          console.log('\x1b[31m%s\x1b[0m', 'Error: Could not read app delegate file');
+
+        }
+      });
+
+    } else {
+
+      console.log('\x1b[31m%s\x1b[0m', 'Error: Could not read project config.xml');
+
+    }
+    
+  });
+
+};

--- a/hooks/removeSquareInit.js
+++ b/hooks/removeSquareInit.js
@@ -1,0 +1,44 @@
+module.exports = function(ctx) {
+  var fs = ctx.requireCordovaModule('fs');
+  var path = ctx.requireCordovaModule('path');
+
+  // Read project config file and get the name of the project
+  var config_path = path.join(__dirname, "/../../../config.xml");
+
+  fs.readFile(config_path, "utf8", function(err, data) {
+    if (!err && data) {
+      var name_start = data.indexOf("<name>");
+      var name_end = data.indexOf("</name>");
+
+      var project_name = data.substring(name_start, name_end);
+      project_name = project_name.replace("<name>", "").trim();
+
+      // next we need to read the file app delegate file
+      var app_delegate_path = path.join(__dirname, "/../../../platforms/ios/" + project_name + "/Classes/AppDelegate.m");
+
+      fs.readFile(app_delegate_path, "utf8", function(err, data) {
+        if (!err && data) {
+          var new_app_delegate_content = data
+            .replace(/\n\#import \<SquareReaderSDK\/SquareReaderSDK.h\>/g, "")
+            .replace(/\n\t\/\/ Initialize Square Reader SDK/g, "")
+            .replace(/\n\t\[SQRDReaderSDK initializeWithApplicationLaunchOptions:launchOptions\];/g, "");
+
+          // Write to the file with the new updates
+          fs.writeFile(app_delegate_path, new_app_delegate_content, function(
+            err
+          ) {
+            if (!err) {
+              console.log('\x1b[32m%s\x1b[0m', 'Success! The Square SDK initializer was removed from the AppDelegate file');
+            } else {
+              console.log('\x1b[31m%s\x1b[0m', 'Error: Could not update app delegate file');
+            }
+          });
+        } else {
+          console.log('\x1b[31m%s\x1b[0m', 'Error: Could not read app delegate file');
+        }
+      });
+    } else {
+      console.log('\x1b[31m%s\x1b[0m', 'Error: Could not read project config.xml');
+    }
+  });
+};

--- a/plugin.xml
+++ b/plugin.xml
@@ -12,6 +12,9 @@
     </js-module>
 
     <platform name="ios">
+        <hook type="after_plugin_install" src="hooks/addSquareInit.js" />
+        <hook type="before_plugin_uninstall" src="hooks/removeSquareInit.js" />
+
         <config-file target="config.xml" parent="/*">
             <feature name="MoltinCordovaSquareReader">
                 <param name="ios-package" value="MoltinCordovaSquareReader" />


### PR DESCRIPTION
Hi there!

I was thinking these js hooks would be helpful in automating some of the set up for the reader SDK. Specifically step 5 in Squares docs here https://docs.connect.squareup.com/payments/readersdk/setup-ios. The js hooks will automatically add and remove the Square code needed in the AppDelegate.m file in the Cordova project.

These are the two pieces of code that are added or removed in the AppDelegate.m file.

```#import <SquareReaderSDK/SquareReaderSDK.h>```

```[SQRDReaderSDK initializeWithApplicationLaunchOptions:launchOptions];```